### PR TITLE
Add long message support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ You can toggle context remebering, and response type.
 ```js
 const chatgpt = new ChatGPTClient('YOUR_OPENAI_API_KEY', {
   contextRemembering: true,
-  responseType: 'embed' // or 'string'
+  responseType: 'embed', // or 'string'
+  maxLength: 20000 // limit GPT responses and split into 2000 char chunks
 });
 ```

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ require('dotenv').config();
   const gpt = await ChatGPTClient.init(process.env.OPENAI_API_KEY, {
     contextRemembering: true,
     responseType: 'embed',
-    maxLength: 2000
+    maxLength: 20000
   });
 
   // Sobald Bot online ist

--- a/src/ChatGPTClient.js
+++ b/src/ChatGPTClient.js
@@ -14,6 +14,14 @@ class ChatGPTClient {
     this.options = Object.assign(optionDefaults, options);
   }
 
+  static splitText(text, size = 2000) {
+    const chunks = [];
+    for (let i = 0; i < text.length; i += size) {
+      chunks.push(text.slice(i, i + size));
+    }
+    return chunks;
+  }
+
   static async init(openAIAPIKey, options) {
     if (!openAIAPIKey) {
       throw new TypeError("❌ OpenAI API Key fehlt!");
@@ -57,7 +65,14 @@ class ChatGPTClient {
     const reply = await this.send(str, this.options.contextRemembering && context ? context : undefined);
 
     if (this.options.responseType === 'string') {
-      await interaction.editReply(reply.text);
+      const text = this.options.maxLength
+        ? reply.text.slice(0, this.options.maxLength)
+        : reply.text;
+      const chunks = ChatGPTClient.splitText(text, 2000);
+      await interaction.editReply(chunks.shift());
+      for (const chunk of chunks) {
+        await interaction.followUp(chunk);
+      }
     } else {
       const embed = new EmbedBuilder()
         .setColor(Colors.DarkerGrey)
@@ -99,7 +114,13 @@ class ChatGPTClient {
     await response.delete().catch(() => null);
 
     if (this.options.responseType === 'string') {
-      await message.reply(reply.text);
+      const text = this.options.maxLength
+        ? reply.text.slice(0, this.options.maxLength)
+        : reply.text;
+      const chunks = ChatGPTClient.splitText(text, 2000);
+      for (const chunk of chunks) {
+        await message.reply(chunk);
+      }
     } else {
       const embed = new EmbedBuilder()
         .setColor(Colors.DarkerGrey)


### PR DESCRIPTION
## Summary
- support splitting long responses into 2000 character chunks
- document `maxLength` option
- increase example maxLength to 20k

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687672bc122c8321ae2498500b069814