### PR TITLE
Add automatic long-response splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ const chatgpt = new ChatGPTClient('YOUR_OPENAI_API_KEY', {
 });
 
 ```
+Longer replies are automatically split and sent in sequence when they exceed Discord's 2000 character limit.


### PR DESCRIPTION
## Summary
- add helper methods to split long responses in chunks
- use the new helpers in interaction and message handling
- document automatic splitting behaviour in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68769fc0573883218fa917237894834e